### PR TITLE
fix(indexer): retry to pull the latest block and receipts from cluster

### DIFF
--- a/internal/service/indexer/l1/indexer.go
+++ b/internal/service/indexer/l1/indexer.go
@@ -2,6 +2,7 @@ package l1
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -9,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum-optimism/optimism/op-bindings/bindings"
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -100,6 +102,12 @@ func (s *server) run(ctx context.Context) (err error) {
 
 		blocks, err := blockResultPool.Wait()
 		if err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				zap.L().Error("blocks not found", zap.Error(err))
+
+				continue
+			}
+
 			return fmt.Errorf("wait block result pool: %w", err)
 		}
 
@@ -132,6 +140,12 @@ func (s *server) run(ctx context.Context) (err error) {
 		}
 
 		if err := receiptsPool.Wait(); err != nil {
+			if errors.Is(err, ethereum.NotFound) {
+				zap.L().Error("receipts not found", zap.Error(err))
+
+				continue
+			}
+
 			return fmt.Errorf("wait receipts pool: %w", err)
 		}
 


### PR DESCRIPTION
Some nodes in the RPC node cluster are a little behind in block heights.

```json
{"level":"fatal","ts":1706085524.0109332,"caller":"cmd/main.go:104","msg":"execute command","error":"get receipts: not found","stacktrace":"main.main\n\t/root/gi/cmd/main.go:104\nruntime.main\n\t/usr/local/go/src/runtime/proc.go:267"}
```