### PR TITLE
fix(database): use Create instead of Save

### DIFF
--- a/internal/database/dialer/cockroachdb/client.go
+++ b/internal/database/dialer/cockroachdb/client.go
@@ -140,7 +140,7 @@ func (c *client) SaveNode(ctx context.Context, data *schema.Node) error {
 		UpdateAll: true,
 	}
 
-	return c.database.WithContext(ctx).Clauses(onConflict).Save(&nodes).Error
+	return c.database.WithContext(ctx).Clauses(onConflict).Create(&nodes).Error
 }
 
 func (c *client) UpdateNodesStatus(ctx context.Context, lastHeartbeatTimestamp int64) error {

--- a/internal/database/dialer/cockroachdb/table/checkpoint.go
+++ b/internal/database/dialer/cockroachdb/table/checkpoint.go
@@ -17,7 +17,7 @@ type Checkpoint struct {
 	ChainID     uint64    `gorm:"column:chain_id"`
 	BlockNumber uint64    `gorm:"column:block_number"`
 	BlockHash   string    `gorm:"column:block_hash"`
-	CreatedAt   time.Time `gorm:"column:created_at;"`
+	CreatedAt   time.Time `gorm:"column:created_at"`
 	UpdatedAt   time.Time `gorm:"column:updated_at"`
 }
 


### PR DESCRIPTION
use Create instead of Save to avoid created_at update to zero when updating an existing column

Save
```bash
"UPDATE \"node_stat\" SET \"endpoint\"='xxx',\"points\"=0,\"is_public_good\"=false,\"is_full_node\"=false,\"is_rss_node\"=true,\"staking\"=0,\"epoch\"=0,\"total_request_count\"=0,\"epoch_request_count\"=0,\"epoch_invalid_request_count\"=0,\"decentralized_network_count\"=10,\"federated_network_count\"=0,\"indexer_count\"=24,\"reset_at\"='2024-01-31 17:12:04.375',\"created_at\"='0000-00-00 00:00:00',\"updated_at\"='2024-01-31 17:38:36.761' WHERE \"address\" = '<binary>'"}
```

Create
```bash
"INSERT INTO \"node_stat\" (\"address\",\"endpoint\",\"points\",\"is_public_good\",\"is_full_node\",\"is_rss_node\",\"staking\",\"epoch\",\"total_request_count\",\"epoch_request_count\",\"epoch_invalid_request_count\",\"decentralized_network_count\",\"federated_network_count\",\"indexer_count\",\"reset_at\",\"created_at\",\"updated_at\") VALUES ('<binary>',xxx',0,false,false,true,0,0,0,0,0,10,0,24,'2024-01-31 17:12:04.375','2024-01-31 17:37:39.787','2024-01-31 17:37:39.787') ON CONFLICT (\"address\") DO UPDATE SET \"updated_at\"='2024-01-31 17:37:39.787',\"endpoint\"=\"excluded\".\"endpoint\",\"points\"=\"excluded\".\"points\",\"is_public_good\"=\"excluded\".\"is_public_good\",\"is_full_node\"=\"excluded\".\"is_full_node\",\"is_rss_node\"=\"excluded\".\"is_rss_node\",\"staking\"=\"excluded\".\"staking\",\"epoch\"=\"excluded\".\"epoch\",\"total_request_count\"=\"excluded\".\"total_request_count\",\"epoch_request_count\"=\"excluded\".\"epoch_request_count\",\"epoch_invalid_request_count\"=\"excluded\".\"epoch_invalid_request_count\",\"decentralized_network_count\"=\"excluded\".\"decentralized_network_count\",\"federated_network_count\"=\"excluded\".\"federated_network_count\",\"indexer_count\"=\"excluded\".\"indexer_count\",\"reset_at\"=\"excluded\".\"reset_at\""}
```

Save will set created_at as '0000-00-00 00:00:00'，On the contrary, Create will not update created_at
