### PR TITLE
fix: pagination support for score

### DIFF
--- a/internal/database/dialer/cockroachdb/client_node.go
+++ b/internal/database/dialer/cockroachdb/client_node.go
@@ -43,7 +43,7 @@ func (c *client) FindNodes(ctx context.Context, query schema.FindNodesQuery) ([]
 			return nil, fmt.Errorf("get node cursor: %w", err)
 		}
 
-		databaseStatement = databaseStatement.Where("created_at < ?", nodeCursor.CreatedAt)
+		databaseStatement = databaseStatement.Where("score < ? OR (score = ? AND created_at < ?)", nodeCursor.Score, nodeCursor.Score, nodeCursor.CreatedAt)
 	}
 
 	if query.Status != nil {

--- a/internal/database/dialer/cockroachdb/migration/20240404203213_create_score_index_for_node_table.sql
+++ b/internal/database/dialer/cockroachdb/migration/20240404203213_create_score_index_for_node_table.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX IF NOT EXISTS "idx_score" ON "public"."node_info" ("score" DESC);
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX IF EXISTS "public"."idx_score";
+-- +goose StatementEnd


### PR DESCRIPTION
1. Corrected pagination for nodes to handle identical scores, ensuring no duplicates or missed entries by using score and create_at time for consistent ordering.
2. Added an index on the score column to improve query performance.