### PR TITLE
fix(hub): invalid pending query parameter

### DIFF
--- a/internal/database/dialer/cockroachdb/client_stake.go
+++ b/internal/database/dialer/cockroachdb/client_stake.go
@@ -93,7 +93,7 @@ func (c *client) FindStakeTransactions(ctx context.Context, query schema.StakeTr
 		databaseClient = databaseClient.Where(`"type" = ?`, query.Type)
 	}
 
-	if query.Pending != nil {
+	if query.Pending != nil && *query.Pending {
 		subQuery := c.database.WithContext(ctx).
 			Select("TRUE").
 			Table((*table.StakeEvent).TableName(nil)).


### PR DESCRIPTION
Related #265. Fixed an incorrect SQL statement condition.

Only `unstake` and `withdraw` transactions can have a `pending` status. However, since the staking contract currently does not support `unstake` and `withdraw` functionalities, there will be **no pending transactions**.

### Statement template

```sql
SELECt *
FROM "stake"."transactions"
WHERE "type" IN ('unstake', 'withdraw') AND NOT EXISTS(
    SELECT TRUE
    FROM "stake"."events"
    WHERE "transactions"."id" = "events"."id" AND "events"."type" = 'claimed'
);
```

| type | count |
| ---- | ----- |
| stake | 1186 |
| deposit | 105 |