### PR TITLE
fix(indexer): use finalized block to avoid block reorganisation

### DIFF
--- a/internal/service/indexer/l1/indexer.go
+++ b/internal/service/indexer/l1/indexer.go
@@ -36,6 +36,7 @@ type server struct {
 	contractL1StandardBridge       *bindings.L1StandardBridge
 	checkpoint                     *schema.Checkpoint
 	blockNumberLatest              uint64
+	blockNumberFinalized           uint64
 	blockThreads                   uint64
 }
 
@@ -79,7 +80,17 @@ func (s *server) refreshLatestBlockNumber(ctx context.Context) (err error) {
 		return fmt.Errorf("get latest block number: %w", err)
 	}
 
-	span.SetAttributes(attribute.Int64("block.number", int64(s.blockNumberLatest)))
+	finalizedBlock, err := s.ethereumClient.BlockByNumber(ctx, big.NewInt(rpc.FinalizedBlockNumber.Int64()))
+	if err != nil {
+		return fmt.Errorf("get finalized block number: %w", err)
+	}
+
+	s.blockNumberFinalized = finalizedBlock.NumberU64()
+
+	span.SetAttributes(
+		attribute.Int64("block.number.latest", int64(s.blockNumberLatest)),
+		attribute.Int64("block.number.finalized", int64(s.blockNumberFinalized)),
+	)
 
 	return nil
 }
@@ -93,7 +104,7 @@ func (s *server) fetchBlocks(ctx context.Context) ([]*types.Block, error) {
 	for offset := uint64(1); offset <= s.blockThreads; offset++ {
 		blockNumber := s.checkpoint.BlockNumber + offset
 
-		if blockNumber > s.blockNumberLatest {
+		if blockNumber > s.blockNumberFinalized {
 			continue
 		}
 
@@ -165,6 +176,7 @@ func (s *server) index(ctx context.Context) (err error) {
 		attribute.Int64("chain.id", s.chainID.Int64()),
 		attribute.Int64("block.number.local", int64(s.checkpoint.BlockNumber)),
 		attribute.Int64("block.number.latest", int64(s.blockNumberLatest)),
+		attribute.Int64("block.number.finalized", int64(s.blockNumberFinalized)),
 	)
 
 	if err := s.refreshLatestBlockNumber(ctx); err != nil {
@@ -175,16 +187,18 @@ func (s *server) index(ctx context.Context) (err error) {
 		"refreshed the latest block number",
 		zap.Uint64("block.number.local", s.checkpoint.BlockNumber),
 		zap.Uint64("block.number.latest", s.blockNumberLatest),
+		zap.Uint64("block.number.finalized", s.blockNumberFinalized),
 	)
 
 	// Waiting for a new block to be minted.
-	if s.checkpoint.BlockNumber >= s.blockNumberLatest {
+	if s.checkpoint.BlockNumber >= s.blockNumberFinalized {
 		blockConfirmationTime := time.Second // TODO Redefine it.
 
 		zap.L().Info(
 			"waiting for a new block to be minted",
 			zap.Uint64("block.number.local", s.checkpoint.BlockNumber),
 			zap.Uint64("block.number.latest", s.blockNumberLatest),
+			zap.Uint64("block.number.finalized", s.blockNumberFinalized),
 			zap.Duration("block.confirmationTime", blockConfirmationTime),
 		)
 


### PR DESCRIPTION
Resolved #274.

This change will cause a delay in block indexing. https://github.com/RSS3-Network/Global-Indexer/issues/274#issuecomment-2185639909

```json
{"level":"info","ts":1719207067.056458,"caller":"l1/indexer.go:186","msg":"refreshed the latest block number","block.number.local":6174156,"block.number.latest":6174235,"block.number.finalized":6174156}
{"level":"info","ts":1719207067.056509,"caller":"l1/indexer.go:197","msg":"waiting for a new block to be minted","block.number.local":6174156,"block.number.latest":6174235,"block.number.finalized":6174156,"block.confirmationTime":1}
{"level":"info","ts":1719207069.251325,"caller":"l2/indexer.go:190","msg":"refreshed the latest block number","block.number.local":5272817,"block.number.latest":5273374,"block.number.finalized":5272817}
{"level":"info","ts":1719207069.251369,"caller":"l2/indexer.go:201","msg":"waiting for a new block to be minted","block.number.local":5272817,"block.number.latest":5273374,"block.number.finalized":5272817,"block.confirmationTime":1}

```