### PR TITLE
fix: validate combined parameters

### DIFF
--- a/internal/service/hub/handler/dsl/activity.go
+++ b/internal/service/hub/handler/dsl/activity.go
@@ -15,6 +15,7 @@ import (
 	"github.com/rss3-network/protocol-go/schema"
 	"github.com/rss3-network/protocol-go/schema/network"
 	"github.com/rss3-network/protocol-go/schema/tag"
+	"github.com/samber/lo"
 	"go.uber.org/zap"
 )
 
@@ -33,7 +34,7 @@ func (d *DSL) GetActivity(c echo.Context) (err error) {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	activity, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestActivity, request)
+	activity, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestActivity, request, nil, nil)
 	if err != nil {
 		zap.L().Error("distribute activity request error", zap.Error(err))
 
@@ -62,7 +63,8 @@ func (d *DSL) GetAccountActivities(c echo.Context) (err error) {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	if err = validParams(request.Tag, request.Network, request.Platform); err != nil {
+	workers, networks, err := validateCombinedParams(request.Tag, request.Network, request.Platform)
+	if err != nil {
 		return errorx.ValidationFailedError(c, err)
 	}
 
@@ -76,7 +78,7 @@ func (d *DSL) GetAccountActivities(c echo.Context) (err error) {
 		}
 	}
 
-	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestAccountActivities, request)
+	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestAccountActivities, request, workers, networks)
 	if err != nil {
 		zap.L().Error("distribute activities data error", zap.Error(err))
 
@@ -105,11 +107,12 @@ func (d *DSL) BatchGetAccountsActivities(c echo.Context) (err error) {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	if err = validParams(request.Tag, request.Network, request.Platform); err != nil {
+	workers, networks, err := validateCombinedParams(request.Tag, request.Network, request.Platform)
+	if err != nil {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestBatchAccountActivities, request)
+	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestBatchAccountActivities, request, workers, networks)
 	if err != nil {
 		zap.L().Error("distribute batch activities data error", zap.Error(err))
 
@@ -138,11 +141,12 @@ func (d *DSL) GetNetworkActivities(c echo.Context) (err error) {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	if err = validParams(request.Tag, []string{request.Network}, request.Platform); err != nil {
+	workers, networks, err := validateCombinedParams(request.Tag, []string{request.Network}, request.Platform)
+	if err != nil {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestNetworkActivities, request)
+	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestNetworkActivities, request, workers, networks)
 	if err != nil {
 		zap.L().Error("distribute network activities data error", zap.Error(err))
 
@@ -171,11 +175,12 @@ func (d *DSL) GetPlatformActivities(c echo.Context) (err error) {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	if err = validParams(request.Tag, request.Network, []string{request.Platform}); err != nil {
+	workers, networks, err := validateCombinedParams(request.Tag, request.Network, []string{request.Platform})
+	if err != nil {
 		return errorx.ValidationFailedError(c, err)
 	}
 
-	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestPlatformActivities, request)
+	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestPlatformActivities, request, workers, networks)
 	if err != nil {
 		zap.L().Error("distribute platform activities data error", zap.Error(err))
 
@@ -226,25 +231,140 @@ func parseParams(params url.Values, tags []string) ([]string, error) {
 	return types, nil
 }
 
-// validParams checks if the tags, networks, and platforms are valid.
-func validParams(tags, networks, platforms []string) error {
-	for _, tagX := range tags {
-		if _, err := tag.TagString(tagX); err != nil {
-			return err
+// validateCombinedParams validates the input tags, networks, and platforms and matches the workers.
+func validateCombinedParams(inputTags, inputNetworks, inputPlatforms []string) ([]string, []string, error) {
+	// Find network nodes that match the network requests.
+	networks, networkWorks, err := getNetworks(inputNetworks)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Find tag workers that match the tag requests.
+	tagWorkers, err := getWorkersByTag(inputTags)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Find platform workers that match the platform requests.
+	platformWorkers, err := getWorkersByPlatform(inputPlatforms)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	workers := combineWorkers(tagWorkers, networkWorks)
+	// If no common workers are found between tag workers and network workers,
+	// it indicates that tags and networks are not compatible.
+	if len(workers) == 0 && (len(tagWorkers) > 0 || len(networkWorks) > 0) {
+		return nil, nil, fmt.Errorf("no workers found for tags and networks")
+	}
+
+	workers = combineWorkers(networkWorks, platformWorkers)
+	// If no common workers are found between network workers and platform workers,
+	// it indicates that networks and platforms are not compatible.
+	if len(workers) == 0 && (len(networkWorks) > 0 || len(platformWorkers) > 0) {
+		return nil, nil, fmt.Errorf("no workers found for networks and platforms")
+	}
+
+	workers = combineWorkers(tagWorkers, platformWorkers)
+	// If no common workers are found between tag workers and platform workers,
+	// it indicates that tags and platforms are not compatible.
+	if len(workers) == 0 && (len(tagWorkers) > 0 || len(platformWorkers) > 0) {
+		return nil, nil, fmt.Errorf("no workers found for tags and platforms")
+	}
+
+	return lo.Keys(workers), networks, nil
+}
+
+type WorkerSet map[string]struct{}
+
+// getNetworks returns a slice of networks based on the given network names.
+func getNetworks(networks []string) ([]string, WorkerSet, error) {
+	networkWorkers := make(WorkerSet)
+
+	for i, n := range networks {
+		nid, err := network.NetworkString(n)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		networks[i] = nid.String()
+
+		networkWorker, exists := model.NetworkToWorkersMap[nid.String()]
+		if !exists {
+			return nil, nil, fmt.Errorf("no workers found for network: %s", nid)
+		}
+
+		for _, w := range networkWorker {
+			networkWorkers[w] = struct{}{}
 		}
 	}
 
-	for _, networkX := range networks {
-		if _, err := network.NetworkString(networkX); err != nil {
-			return err
+	return networks, networkWorkers, nil
+}
+
+// getWorkersByTag returns a set of workers based on the given tags.
+func getWorkersByTag(tags []string) (WorkerSet, error) {
+	tagWorkers := make(WorkerSet)
+
+	for _, tagX := range tags {
+		tid, err := tag.TagString(tagX)
+		if err != nil {
+			return nil, err
+		}
+
+		tagWorker, exists := model.TagToWorkersMap[tid.String()]
+		if !exists {
+			return nil, fmt.Errorf("no workers found for tag: %s", tid)
+		}
+
+		for _, w := range tagWorker {
+			tagWorkers[w] = struct{}{}
 		}
 	}
+
+	return tagWorkers, nil
+}
+
+// getWorkersByPlatform returns a set of workers based on the given platforms.
+func getWorkersByPlatform(platforms []string) (WorkerSet, error) {
+	platformWorkers := make(WorkerSet)
 
 	for _, platform := range platforms {
-		if _, err := decentralized.PlatformString(platform); err != nil {
-			return err
+		pid, err := decentralized.PlatformString(platform)
+		if err != nil {
+			return nil, err
+		}
+
+		workers, exists := model.PlatformToWorkersMap[pid.String()]
+		if !exists {
+			return nil, fmt.Errorf("no worker found for platform: %s", pid)
+		}
+
+		for _, w := range workers {
+			platformWorkers[w] = struct{}{}
 		}
 	}
 
-	return nil
+	return platformWorkers, nil
+}
+
+// combineWorkers combines two worker sets.
+func combineWorkers(workers1, workers2 WorkerSet) WorkerSet {
+	if len(workers1) == 0 {
+		return workers2
+	}
+
+	if len(workers2) == 0 {
+		return workers1
+	}
+
+	commonWorkers := make(WorkerSet)
+
+	for w := range workers1 {
+		if _, exists := workers2[w]; exists {
+			commonWorkers[w] = struct{}{}
+		}
+	}
+
+	return commonWorkers
 }

--- a/internal/service/hub/handler/dsl/activity.go
+++ b/internal/service/hub/handler/dsl/activity.go
@@ -255,21 +255,21 @@ func validateCombinedParams(inputTags, inputNetworks, inputPlatforms []string) (
 	// If no common workers are found between tag workers and network workers,
 	// it indicates that tags and networks are not compatible.
 	if len(workers) == 0 && (len(tagWorkers) > 0 || len(networkWorks) > 0) {
-		return nil, nil, fmt.Errorf("no workers found for tags and networks")
+		return nil, nil, fmt.Errorf("no workers meet the conditions tags and networks")
 	}
 
 	workers = combineWorkers(networkWorks, platformWorkers)
 	// If no common workers are found between network workers and platform workers,
 	// it indicates that networks and platforms are not compatible.
 	if len(workers) == 0 && (len(networkWorks) > 0 || len(platformWorkers) > 0) {
-		return nil, nil, fmt.Errorf("no workers found for networks and platforms")
+		return nil, nil, fmt.Errorf("no workers meet the conditions networks and platforms")
 	}
 
 	workers = combineWorkers(tagWorkers, platformWorkers)
 	// If no common workers are found between tag workers and platform workers,
 	// it indicates that tags and platforms are not compatible.
 	if len(workers) == 0 && (len(tagWorkers) > 0 || len(platformWorkers) > 0) {
-		return nil, nil, fmt.Errorf("no workers found for tags and platforms")
+		return nil, nil, fmt.Errorf("no workers meet the conditions tags and platforms")
 	}
 
 	return lo.Keys(workers), networks, nil

--- a/internal/service/hub/handler/dsl/distributor/distributor.go
+++ b/internal/service/hub/handler/dsl/distributor/distributor.go
@@ -67,7 +67,7 @@ func (d *Distributor) generateRSSHubPath(param, query string, nodes []*model.Nod
 }
 
 // DistributeDecentralizedData distributes decentralized requests to qualified Nodes.
-func (d *Distributor) DistributeDecentralizedData(ctx context.Context, requestType string, request interface{}) ([]byte, error) {
+func (d *Distributor) DistributeDecentralizedData(ctx context.Context, requestType string, request interface{}, workers, networks []string) ([]byte, error) {
 	var (
 		nodes          []*model.NodeEndpointCache
 		processResults = d.processActivitiesResponses
@@ -80,28 +80,13 @@ func (d *Distributor) DistributeDecentralizedData(ctx context.Context, requestTy
 		nodes, err = d.simpleEnforcer.RetrieveQualifiedNodes(ctx, model.FullNodeCacheKey)
 		processResults = d.processActivityResponses
 	case model.DistributorRequestAccountActivities:
-		nodes, err = d.getQualifiedNodes(ctx, request.(dsl.ActivitiesRequest))
+		nodes, err = d.getQualifiedNodes(ctx, workers, networks)
 	case model.DistributorRequestBatchAccountActivities:
-		req := request.(dsl.AccountsActivitiesRequest)
-		nodes, err = d.getQualifiedNodes(ctx, dsl.ActivitiesRequest{
-			Network:  req.Network,
-			Platform: req.Platform,
-			Tag:      req.Tag,
-		})
+		nodes, err = d.getQualifiedNodes(ctx, workers, networks)
 	case model.DistributorRequestNetworkActivities:
-		req := request.(dsl.NetworkActivitiesRequest)
-		nodes, err = d.getQualifiedNodes(ctx, dsl.ActivitiesRequest{
-			Network:  []string{req.Network},
-			Platform: req.Platform,
-			Tag:      req.Tag,
-		})
+		nodes, err = d.getQualifiedNodes(ctx, workers, networks)
 	case model.DistributorRequestPlatformActivities:
-		req := request.(dsl.PlatformActivitiesRequest)
-		nodes, err = d.getQualifiedNodes(ctx, dsl.ActivitiesRequest{
-			Platform: []string{req.Platform},
-			Network:  req.Network,
-			Tag:      req.Tag,
-		})
+		nodes, err = d.getQualifiedNodes(ctx, workers, networks)
 	default:
 		return nil, fmt.Errorf("invalid request type: %s", requestType)
 	}

--- a/internal/service/hub/handler/dsl/distributor/match.go
+++ b/internal/service/hub/handler/dsl/distributor/match.go
@@ -2,114 +2,18 @@ package distributor
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rss3-network/global-indexer/internal/service/hub/handler/dsl/model"
-	"github.com/rss3-network/global-indexer/internal/service/hub/model/dsl"
 	"github.com/rss3-network/global-indexer/schema"
 	"github.com/rss3-network/node/schema/worker/decentralized"
 	"github.com/rss3-network/protocol-go/schema/network"
-	"github.com/rss3-network/protocol-go/schema/tag"
 	"github.com/samber/lo"
 )
 
 // matchLightNodes matches light Nodes based on the given Activities request
 // A light Node is a non-Full Node
-func (d *Distributor) matchLightNodes(ctx context.Context, request dsl.ActivitiesRequest) ([]common.Address, error) {
-	// Find network nodes that match the network requests.
-	networks, err := getNetworks(request.Network)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find tag workers that match the tag requests.
-	tagWorkers, err := getWorkersByTag(request.Tag)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find platform workers that match the platform requests.
-	platformWorkers, err := getWorkersByPlatform(request.Platform)
-	if err != nil {
-		return nil, err
-	}
-
-	// Find nodes that match the tag workers, platform workers, and networks.
-	return d.findQualifiedNodes(ctx, tagWorkers, platformWorkers, networks)
-}
-
-type WorkerSet map[string]struct{}
-
-// getNetworks returns a slice of networks based on the given network names.
-func getNetworks(networks []string) ([]string, error) {
-	for i, n := range networks {
-		nid, err := network.NetworkString(n)
-		if err != nil {
-			return nil, err
-		}
-
-		networks[i] = nid.String()
-	}
-
-	return networks, nil
-}
-
-// getWorkersByTag returns a set of workers based on the given tags.
-func getWorkersByTag(tags []string) (WorkerSet, error) {
-	tagWorkers := make(WorkerSet)
-
-	for _, tagX := range tags {
-		tid, err := tag.TagString(tagX)
-		if err != nil {
-			return nil, err
-		}
-
-		tagWorker, exists := model.TagToWorkersMap[tid.String()]
-		if !exists {
-			return nil, fmt.Errorf("no workers found for tag: %s", tid)
-		}
-
-		for _, w := range tagWorker {
-			tagWorkers[w] = struct{}{}
-		}
-	}
-
-	return tagWorkers, nil
-}
-
-// getWorkersByPlatform returns a set of workers based on the given platforms.
-func getWorkersByPlatform(platforms []string) (WorkerSet, error) {
-	platformWorkers := make(WorkerSet)
-
-	for _, platform := range platforms {
-		pid, err := decentralized.PlatformString(platform)
-		if err != nil {
-			return nil, err
-		}
-
-		workers, exists := model.PlatformToWorkersMap[pid.String()]
-		if !exists {
-			return nil, fmt.Errorf("no worker found for platform: %s", pid)
-		}
-
-		for _, w := range workers {
-			platformWorkers[w] = struct{}{}
-		}
-	}
-
-	return platformWorkers, nil
-}
-
-// findQualifiedNodes finds nodes that match the given tag workers, platform workers, and networks.
-func (d *Distributor) findQualifiedNodes(ctx context.Context, tagWorkers, platformWorkers WorkerSet, networks []string) ([]common.Address, error) {
-	workers := combineTagAndPlatformWorkers(tagWorkers, platformWorkers)
-	// If no common workers are found between tag workers and platform workers,
-	// it indicates that tags and platforms are not compatible.
-	if len(workers) == 0 && (len(tagWorkers) > 0 || len(platformWorkers) > 0) {
-		return nil, fmt.Errorf("no workers found for tags and platforms")
-	}
-
+func (d *Distributor) matchLightNodes(ctx context.Context, workers, networks []string) ([]common.Address, error) {
 	var (
 		nodes []common.Address
 		err   error
@@ -122,24 +26,9 @@ func (d *Distributor) findQualifiedNodes(ctx context.Context, tagWorkers, platfo
 		nodes, err = d.matchWorker(ctx, workers)
 	case len(networks) > 0:
 		nodes, err = d.matchNetwork(ctx, networks)
-	default:
 	}
 
 	return nodes, err
-}
-
-// combineTagAndPlatformWorkers combines tag workers and platform workers.
-func combineTagAndPlatformWorkers(tagWorkers, platformWorkers WorkerSet) []string {
-	if len(tagWorkers) == 0 {
-		return lo.Keys(platformWorkers)
-	}
-
-	if len(platformWorkers) == 0 {
-		return lo.Keys(tagWorkers)
-	}
-
-	// Find common workers between tag workers and platform workers.
-	return IntersectUnique(lo.Keys(tagWorkers), lo.Keys(platformWorkers))
 }
 
 // matchNetwork matches nodes based on the given network requests,

--- a/internal/service/hub/handler/dsl/distributor/match.go
+++ b/internal/service/hub/handler/dsl/distributor/match.go
@@ -6,8 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rss3-network/global-indexer/internal/service/hub/handler/dsl/model"
 	"github.com/rss3-network/global-indexer/schema"
-	"github.com/rss3-network/node/schema/worker/decentralized"
-	"github.com/rss3-network/protocol-go/schema/network"
 	"github.com/samber/lo"
 )
 
@@ -90,10 +88,8 @@ func isValidNetworkNode(networkWorkersMap NetworkWorkersMap, requestNetworks []s
 	}
 
 	for n, workers := range networkWorkersMap.Workers {
-		nid, _ := network.NetworkString(n)
-
 		// Check if the workers match the required workers for the network.
-		requiredWorkers := model.NetworkToWorkersMap[nid.String()]
+		requiredWorkers := model.NetworkToWorkersMap[n]
 		if !AreSliceElementsIdentical(workers, requiredWorkers) {
 			return false
 		}
@@ -158,9 +154,7 @@ func isValidWorkerNode(workerNetworksMap WorkerNetworksMap, workers []string) bo
 	}
 
 	for w, networks := range workerNetworksMap.Networks {
-		wid, _ := decentralized.WorkerString(w)
-
-		requiredNetworks := model.WorkerToNetworksMap[wid.String()]
+		requiredNetworks := model.WorkerToNetworksMap[w]
 		if !AreSliceElementsIdentical(networks, requiredNetworks) {
 			return false
 		}
@@ -206,9 +200,7 @@ func isValidWorkerAndNetworkNode(workerNetworksMap WorkerNetworksMap, workers, r
 	}
 
 	for w, networks := range workerNetworksMap.Networks {
-		wid, _ := decentralized.WorkerString(w)
-
-		workerRequiredNetworks := model.WorkerToNetworksMap[wid.String()]
+		workerRequiredNetworks := model.WorkerToNetworksMap[w]
 
 		requiredNetworks := IntersectUnique(workerRequiredNetworks, requestNetworks)
 

--- a/internal/service/hub/handler/dsl/distributor/qualified_node.go
+++ b/internal/service/hub/handler/dsl/distributor/qualified_node.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rss3-network/global-indexer/internal/service/hub/handler/dsl/model"
-	"github.com/rss3-network/global-indexer/internal/service/hub/model/dsl"
 	"github.com/rss3-network/global-indexer/schema"
 	"github.com/samber/lo"
 )
@@ -13,9 +12,9 @@ import (
 // A qualified Node has the capability to serve the incoming request.
 
 // getQualifiedNodes retrieves all qualified Nodes from the cache or database.
-func (d *Distributor) getQualifiedNodes(ctx context.Context, request dsl.ActivitiesRequest) ([]*model.NodeEndpointCache, error) {
+func (d *Distributor) getQualifiedNodes(ctx context.Context, workers, networks []string) ([]*model.NodeEndpointCache, error) {
 	// Match light Nodes.
-	lightNodes, err := d.matchLightNodes(ctx, request)
+	lightNodes, err := d.matchLightNodes(ctx, workers, networks)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/service/hub/handler/dsl/enforcer/maintain_epoch_data_test.go
+++ b/internal/service/hub/handler/dsl/enforcer/maintain_epoch_data_test.go
@@ -171,12 +171,12 @@ func TestGenerateMaps(t *testing.T) {
 			network.Polygon.String():           {},
 			network.SatoshiVM.String():         {},
 			network.VSL.String():               {},
-			network.Farcaster.String():         {},
-			network.Crossbell.String():         {},
-			network.Arbitrum.String():          {},
-			network.Gnosis.String():            {},
-			network.Avalanche.String():         {},
-			network.Base.String():              {},
+			//network.Farcaster.String():         {},
+			network.Crossbell.String(): {},
+			network.Arbitrum.String():  {},
+			network.Gnosis.String():    {},
+			network.Avalanche.String(): {},
+			network.Base.String():      {},
 		},
 		decentralized.Curve.String(): {
 			network.Arbitrum.String():  {},
@@ -185,6 +185,9 @@ func TestGenerateMaps(t *testing.T) {
 			network.Gnosis.String():    {},
 			network.Optimism.String():  {},
 			network.Polygon.String():   {},
+		},
+		"farcaster": {
+			network.Farcaster.String(): {},
 		},
 		decentralized.Highlight.String(): {
 			network.Ethereum.String(): {},
@@ -346,7 +349,7 @@ func TestGenerateMaps(t *testing.T) {
 		},
 
 		network.Farcaster.String(): {
-			decentralized.Core.String(): {},
+			"farcaster": {},
 		},
 	}
 
@@ -369,7 +372,7 @@ func TestGenerateMaps(t *testing.T) {
 		decentralized.PlatformStargate.String():   {decentralized.Stargate.String(): {}},
 		decentralized.PlatformUniswap.String():    {decentralized.Uniswap.String(): {}},
 		decentralized.PlatformVSL.String():        {decentralized.VSL.String(): {}},
-		decentralized.PlatformFarcaster.String():  {decentralized.Core.String(): {}},
+		decentralized.PlatformFarcaster.String():  {"farcaster": {}},
 		decentralized.PlatformLens.String():       {decentralized.Lens.String(): {}, decentralized.Momoka.String(): {}},
 		decentralized.PlatformMirror.String():     {decentralized.Mirror.String(): {}},
 		decentralized.PlatformParagraph.String():  {decentralized.Paragraph.String(): {}},
@@ -402,7 +405,7 @@ func TestGenerateMaps(t *testing.T) {
 		tag.Social.String(): {
 			decentralized.KiwiStand.String(): {},
 			decentralized.IQWiki.String():    {},
-			decentralized.Core.String():      {},
+			"farcaster":                      {},
 			decentralized.Momoka.String():    {},
 			decentralized.Lens.String():      {},
 			decentralized.Mirror.String():    {},

--- a/internal/service/hub/handler/dsl/model/model.go
+++ b/internal/service/hub/handler/dsl/model/model.go
@@ -56,6 +56,12 @@ var (
 		decentralized.PlatformFarcaster.String(): {},
 	}
 
+	// RenameWorkerMap is a map of workers to their corresponding names.
+	// Dealing with some unclear expressions may lead to problems in distributing tasks to workers.
+	RenameWorkerMap = map[network.Network]string{
+		network.Farcaster: "farcaster",
+	}
+
 	// WorkerToNetworksMap is a map of workers to networks, filtering out the complete network types that workers support.
 	WorkerToNetworksMap = make(map[string][]string, len(decentralized.WorkerValues()))
 	// NetworkToWorkersMap is a map of Networks to Workers, filtering out the complete worker types that networks support.


### PR DESCRIPTION
Before distributing requests, verify that the combination of parameters meets the requirements to `reduce the incidence of empty results returned to users due to non-compliant parameters`, and to `decrease the load of ineffective requests on network nodes`.