### PR TITLE
feat: add name service cache

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -1155,7 +1155,7 @@
                     "metadata": {
                         "description": "Additional metadata related to the action.",
                         "type": "object"
-                    ,"anyOf":[{"$ref":"#/components/schemas/ExchangeSwap"},{"$ref":"#/components/schemas/ExchangeLiquidity"},{"$ref":"#/components/schemas/ExchangeStaking"},{"$ref":"#/components/schemas/SocialProfile"},{"$ref":"#/components/schemas/SocialProxy"},{"$ref":"#/components/schemas/SocialPost"},{"$ref":"#/components/schemas/SocialRevise"},{"$ref":"#/components/schemas/SocialShare"},{"$ref":"#/components/schemas/SocialMint"},{"$ref":"#/components/schemas/SocialComment"},{"$ref":"#/components/schemas/SocialReward"},{"$ref":"#/components/schemas/SocialDelete"},{"$ref":"#/components/schemas/MetaverseBurn"},{"$ref":"#/components/schemas/MetaverseMint"},{"$ref":"#/components/schemas/MetaverseTransfer"},{"$ref":"#/components/schemas/MetaverseTrade"},{"$ref":"#/components/schemas/RssFeed"},{"$ref":"#/components/schemas/TransactionApproval"},{"$ref":"#/components/schemas/TransactionBridge"},{"$ref":"#/components/schemas/TransactionTransfer"},{"$ref":"#/components/schemas/TransactionBurn"},{"$ref":"#/components/schemas/TransactionMint"},{"$ref":"#/components/schemas/CollectibleApproval"},{"$ref":"#/components/schemas/CollectibleTrade"},{"$ref":"#/components/schemas/CollectibleTransfer"},{"$ref":"#/components/schemas/CollectibleBurn"},{"$ref":"#/components/schemas/CollectibleMint"}]},
+                    ,"anyOf":[{"$ref":"#/components/schemas/TransactionApproval"},{"$ref":"#/components/schemas/TransactionBridge"},{"$ref":"#/components/schemas/TransactionTransfer"},{"$ref":"#/components/schemas/TransactionBurn"},{"$ref":"#/components/schemas/TransactionMint"},{"$ref":"#/components/schemas/CollectibleMint"},{"$ref":"#/components/schemas/CollectibleApproval"},{"$ref":"#/components/schemas/CollectibleTrade"},{"$ref":"#/components/schemas/CollectibleTransfer"},{"$ref":"#/components/schemas/CollectibleBurn"},{"$ref":"#/components/schemas/ExchangeLiquidity"},{"$ref":"#/components/schemas/ExchangeStaking"},{"$ref":"#/components/schemas/ExchangeSwap"},{"$ref":"#/components/schemas/SocialReward"},{"$ref":"#/components/schemas/SocialShare"},{"$ref":"#/components/schemas/SocialDelete"},{"$ref":"#/components/schemas/SocialComment"},{"$ref":"#/components/schemas/SocialRevise"},{"$ref":"#/components/schemas/SocialMint"},{"$ref":"#/components/schemas/SocialProfile"},{"$ref":"#/components/schemas/SocialProxy"},{"$ref":"#/components/schemas/SocialPost"},{"$ref":"#/components/schemas/MetaverseBurn"},{"$ref":"#/components/schemas/MetaverseMint"},{"$ref":"#/components/schemas/MetaverseTransfer"},{"$ref":"#/components/schemas/MetaverseTrade"},{"$ref":"#/components/schemas/RssFeed"}]},
                     "platform": {
                         "$ref": "#/components/schemas/Platform"
                     },
@@ -2982,6 +2982,7 @@
                             "properties": {
                                 "accounts": {
                                     "type": "array",
+                                    "maxItems": 20,
                                     "items": {
                                         "type": "string"
                                     },

--- a/internal/cache/client.go
+++ b/internal/cache/client.go
@@ -3,13 +3,14 @@ package cache
 import (
 	"context"
 	"encoding/json"
+	"time"
 
 	"github.com/redis/go-redis/v9"
 )
 
 type Client interface {
 	Get(ctx context.Context, key string, dest interface{}) error
-	Set(ctx context.Context, key string, value interface{}) error
+	Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error
 	IncrBy(ctx context.Context, key string, value int64) error
 	PSubscribe(ctx context.Context, pattern string) *redis.PubSub
 	ZAdd(ctx context.Context, key string, members ...redis.Z) error
@@ -33,13 +34,13 @@ func (c *client) Get(ctx context.Context, key string, dest interface{}) error {
 	return json.Unmarshal(data, dest)
 }
 
-func (c *client) Set(ctx context.Context, key string, value interface{}) error {
+func (c *client) Set(ctx context.Context, key string, value interface{}, expiration time.Duration) error {
 	data, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
 
-	return c.redisClient.Set(ctx, key, data, 0).Err()
+	return c.redisClient.Set(ctx, key, data, expiration).Err()
 }
 
 func (c *client) IncrBy(ctx context.Context, key string, value int64) error {

--- a/internal/service/hub/handler/dsl/activity.go
+++ b/internal/service/hub/handler/dsl/activity.go
@@ -1,13 +1,18 @@
 package dsl
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
 	"regexp"
+	"strings"
+	"time"
 
 	"github.com/creasty/defaults"
 	"github.com/labstack/echo/v4"
+	"github.com/redis/go-redis/v9"
 	"github.com/rss3-network/global-indexer/internal/service/hub/handler/dsl/model"
 	"github.com/rss3-network/global-indexer/internal/service/hub/model/dsl"
 	"github.com/rss3-network/global-indexer/internal/service/hub/model/errorx"
@@ -15,6 +20,8 @@ import (
 	"github.com/rss3-network/protocol-go/schema"
 	"github.com/rss3-network/protocol-go/schema/network"
 	"github.com/rss3-network/protocol-go/schema/tag"
+	"github.com/samber/lo"
+	"github.com/sourcegraph/conc/pool"
 	"go.uber.org/zap"
 )
 
@@ -68,10 +75,8 @@ func (d *DSL) GetAccountActivities(c echo.Context) (err error) {
 
 	// Resolve name to EVM address
 	if !validEvmAddress(request.Account) {
-		request.Account, err = d.nameService.Resolve(c.Request().Context(), request.Account)
+		request.Account, err = d.getEVMAddress(c.Request().Context(), request.Account)
 		if err != nil {
-			zap.L().Error("name service resolve error", zap.Error(err), zap.String("account", request.Account))
-
 			return errorx.BadRequestError(c, err)
 		}
 	}
@@ -108,6 +113,13 @@ func (d *DSL) BatchGetAccountsActivities(c echo.Context) (err error) {
 	if err = validParams(request.Tag, request.Network, request.Platform); err != nil {
 		return errorx.ValidationFailedError(c, err)
 	}
+
+	// Resolve names to EVM addresses
+	if err = d.transformAccounts(c.Request().Context(), request.Accounts); err != nil {
+		return errorx.BadRequestError(c, err)
+	}
+
+	request.Accounts = lo.Uniq(request.Accounts)
 
 	activities, err := d.distributor.DistributeDecentralizedData(c.Request().Context(), model.DistributorRequestBatchAccountActivities, request)
 	if err != nil {
@@ -183,6 +195,71 @@ func (d *DSL) GetPlatformActivities(c echo.Context) (err error) {
 	}
 
 	return c.JSONBlob(http.StatusOK, activities)
+}
+
+func (d *DSL) transformAccounts(ctx context.Context, accounts []string) error {
+	var err error
+
+	nsPool := pool.New().WithContext(ctx).WithCancelOnError().WithFirstError().WithMaxGoroutines(len(accounts))
+
+	for i := range accounts {
+		i := i
+
+		nsPool.Go(func(ctx context.Context) error {
+			if !validEvmAddress(accounts[i]) {
+				accounts[i], err = d.getEVMAddress(ctx, accounts[i])
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+	}
+
+	if err = nsPool.Wait(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (d *DSL) getEVMAddress(ctx context.Context, account string) (string, error) {
+	var (
+		err error
+
+		key = buildNameServiceKey(account)
+	)
+	// Try to get the resolved address from Redis cache first
+	if err = d.cacheClient.Get(ctx, key, &account); err == nil {
+		return account, nil
+	}
+
+	// If not found in cache, resolve the name to an EVM address
+	if errors.Is(err, redis.Nil) {
+		// Cache miss, need to resolve the name
+		account, err = d.nameService.Resolve(ctx, account)
+		if err != nil {
+			zap.L().Error("name service resolve error", zap.Error(err), zap.String("account", account))
+
+			return "", err
+		}
+
+		// Cache the resolved address, with a TTL of 10 minutes
+		// Fixme: The TTL should be configurable
+		if err = d.cacheClient.Set(ctx, key, account, 10*time.Minute); err != nil {
+			return "", err
+		}
+
+		return account, nil
+	}
+
+	return "", err
+}
+
+// buildNameServiceKey builds the key for the name service cache.
+func buildNameServiceKey(account string) string {
+	return fmt.Sprintf("name:service:%s", strings.ToLower(account))
 }
 
 // validEvmAddress checks if the address is a valid EVM address.

--- a/internal/service/hub/handler/dsl/activity.go
+++ b/internal/service/hub/handler/dsl/activity.go
@@ -76,9 +76,9 @@ func (d *DSL) GetAccountActivities(c echo.Context) (err error) {
 
 	// Resolve name to EVM address
 	if !validEvmAddress(request.Account) {
-		request.Account, err = d.getEVMAddress(c.Request().Context(), request.Account)
-		if err != nil {
-			return errorx.BadRequestError(c, err)
+		resolvedName, err := d.getEVMAddress(c.Request().Context(), request.Account)
+		if err == nil {
+			request.Account = resolvedName
 		}
 	}
 
@@ -211,9 +211,9 @@ func (d *DSL) transformAccounts(ctx context.Context, accounts []string) error {
 
 		nsPool.Go(func(ctx context.Context) error {
 			if !validEvmAddress(accounts[i]) {
-				accounts[i], err = d.getEVMAddress(ctx, accounts[i])
-				if err != nil {
-					return err
+				resolvedName, err := d.getEVMAddress(ctx, accounts[i])
+				if err == nil {
+					accounts[i] = resolvedName
 				}
 			}
 

--- a/internal/service/hub/handler/dsl/activity.go
+++ b/internal/service/hub/handler/dsl/activity.go
@@ -204,7 +204,7 @@ func (d *DSL) GetPlatformActivities(c echo.Context) (err error) {
 func (d *DSL) transformAccounts(ctx context.Context, accounts []string) error {
 	var err error
 
-	nsPool := pool.New().WithContext(ctx).WithCancelOnError().WithFirstError().WithMaxGoroutines(len(accounts))
+	nsPool := pool.New().WithContext(ctx).WithCancelOnError().WithFirstError()
 
 	for i := range accounts {
 		i := i

--- a/internal/service/hub/handler/dsl/enforcer/maintain_epoch_data.go
+++ b/internal/service/hub/handler/dsl/enforcer/maintain_epoch_data.go
@@ -201,7 +201,7 @@ func (e *SimpleEnforcer) setMapCache(ctx context.Context) error {
 		go func(i int) {
 			defer wg.Done()
 
-			if err := e.cacheClient.Set(ctx, keys[i], maps[i]); err != nil {
+			if err := e.cacheClient.Set(ctx, keys[i], maps[i], 0); err != nil {
 				errChan <- err
 			}
 		}(i)
@@ -508,7 +508,7 @@ func (e *SimpleEnforcer) updateNodeCache(ctx context.Context, epoch int64) error
 		}
 	}
 
-	return e.cacheClient.Set(ctx, model.SubscribeNodeCacheKey, epoch)
+	return e.cacheClient.Set(ctx, model.SubscribeNodeCacheKey, epoch, 0)
 }
 
 // updateSortedSetForNodeType updates the sorted set for different types of Nodes.

--- a/internal/service/hub/handler/dsl/enforcer/maintain_reliability_score.go
+++ b/internal/service/hub/handler/dsl/enforcer/maintain_reliability_score.go
@@ -183,11 +183,11 @@ func (e *SimpleEnforcer) updateStatsInPool(ctx context.Context, stats []*schema.
 			} else {
 				stats[i].EpochRequest = 0
 
-				if err := e.cacheClient.Set(ctx, formatNodeStatRedisKey(model.ValidRequestCount, stats[i].Address.String()), 0); err != nil {
+				if err := e.cacheClient.Set(ctx, formatNodeStatRedisKey(model.ValidRequestCount, stats[i].Address.String()), 0, 0); err != nil {
 					return fmt.Errorf("reset valid request count: %w", err)
 				}
 
-				if err := e.cacheClient.Set(ctx, formatNodeStatRedisKey(model.InvalidRequestCount, stats[i].Address.String()), stats[i].EpochInvalidRequest); err != nil {
+				if err := e.cacheClient.Set(ctx, formatNodeStatRedisKey(model.InvalidRequestCount, stats[i].Address.String()), stats[i].EpochInvalidRequest, 0); err != nil {
 					return fmt.Errorf("reset invalid request count: %w", err)
 				}
 			}

--- a/internal/service/hub/handler/dsl/enforcer/score_maintainer.go
+++ b/internal/service/hub/handler/dsl/enforcer/score_maintainer.go
@@ -199,7 +199,7 @@ func getCacheCount(ctx context.Context, cacheClient cache.Client, key string, ad
 	if err := cacheClient.Get(ctx, formatNodeStatRedisKey(key, address.String()), resCount); err != nil {
 		if errors.Is(err, redis.Nil) {
 			*resCount = statCount
-			return cacheClient.Set(ctx, formatNodeStatRedisKey(key, address.String()), resCount)
+			return cacheClient.Set(ctx, formatNodeStatRedisKey(key, address.String()), resCount, 0)
 		}
 
 		return err

--- a/internal/service/hub/handler/nta/node_hide_tax_rate.go
+++ b/internal/service/hub/handler/nta/node_hide_tax_rate.go
@@ -30,7 +30,7 @@ func (n *NTA) PostNodeHideTaxRate(c echo.Context) error {
 	}
 
 	// Cache the hide tax rate status
-	if err := n.cacheClient.Set(c.Request().Context(), n.buildNodeHideTaxRateKey(request.NodeAddress), true); err != nil {
+	if err := n.cacheClient.Set(c.Request().Context(), n.buildNodeHideTaxRateKey(request.NodeAddress), true, 0); err != nil {
 		zap.L().Error("cache hide tax value", zap.Error(err))
 
 		return errorx.InternalError(c)

--- a/internal/service/hub/model/dsl/decentralized.go
+++ b/internal/service/hub/model/dsl/decentralized.go
@@ -25,7 +25,7 @@ type ActivitiesRequest struct {
 
 // AccountsActivitiesRequest represents the request for activities by multiple accounts.
 type AccountsActivitiesRequest struct {
-	Accounts       []string `json:"accounts" validate:"required"`
+	Accounts       []string `json:"accounts" validate:"required,max=20"`
 	Limit          int      `json:"limit" validate:"min=1,max=100" default:"100"`
 	ActionLimit    int      `json:"action_limit" validate:"min=1,max=20" default:"10"`
 	Cursor         *string  `json:"cursor"`

--- a/internal/service/scheduler/snapshot/apy/apy.go
+++ b/internal/service/scheduler/snapshot/apy/apy.go
@@ -173,7 +173,7 @@ func (s *server) saveAPYToSnapshots(ctx context.Context, latestEpochSnapshot uin
 		return fmt.Errorf("find epoch APY snapshots average: %w", err)
 	}
 
-	if err := s.cacheClient.Set(ctx, CacheKeyEpochAverageAPY, apy); err != nil {
+	if err := s.cacheClient.Set(ctx, CacheKeyEpochAverageAPY, apy, 0); err != nil {
 		return fmt.Errorf("set epoch average APY to cache: %w", err)
 	}
 


### PR DESCRIPTION
1. Add domain name resolution to the `/decentralized/accounts` API endpoint.
2. Implement caching for domain name resolutions, setting the default cache expiration time to 10 minutes.
3. Limit the number of accounts in batch queries to a maximum of 20 per request to minimize delays caused by cache misses.