### PR TITLE
perf(hub): refactor stakings api

### DIFF
--- a/internal/database/dialer/cockroachdb/client_stake.go
+++ b/internal/database/dialer/cockroachdb/client_stake.go
@@ -2,10 +2,12 @@ package cockroachdb
 
 import (
 	"context"
+	"database/sql"
 	"encoding/base64"
 	"errors"
 	"fmt"
 	"math/big"
+	"slices"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -15,6 +17,7 @@ import (
 	"github.com/rss3-network/global-indexer/schema"
 	"github.com/samber/lo"
 	"github.com/shopspring/decimal"
+	"github.com/sourcegraph/conc/pool"
 	"gorm.io/gorm"
 	"gorm.io/gorm/clause"
 )
@@ -247,84 +250,89 @@ func (c *client) DeleteStakeChipsByBlockNumber(ctx context.Context, blockNumber 
 }
 
 func (c *client) FindStakeStakings(ctx context.Context, query schema.StakeStakingsQuery) ([]*schema.StakeStaking, error) {
-	databaseClient := c.database.
-		WithContext(ctx).
-		Table((*table.StakeChip).TableName(nil))
-
-	databaseClient = databaseClient.Where(`"owner" != ?`, ethereum.AddressGenesis.String())
+	databaseClient := c.database.WithContext(ctx)
 
 	if query.Cursor != nil {
 		cursor, err := base64.StdEncoding.DecodeString(*query.Cursor)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("invalid curosr: %w", err)
 		}
 
 		splits := strings.Split(string(cursor), "-")
-		if len(splits) != 2 {
-			return nil, fmt.Errorf("invalid cursor: %w", err)
+		if length := len(splits); length != 3 {
+			return nil, fmt.Errorf("invalid curosr length: %d", length)
 		}
 
 		databaseClient = databaseClient.Where(
-			`"owner" > ? OR ("owner" = ? AND "node" > ?)`,
-			splits[0], splits[0], splits[1],
+			`"value" < @value OR ("value" = @value AND "staker" > @staker) OR ("value" = @value AND "staker" = @staker AND "node" > @node)`,
+			sql.Named("value", splits[0]),
+			sql.Named("staker", splits[1]),
+			sql.Named("node", splits[2]),
 		)
 	}
 
 	if query.Staker != nil {
-		databaseClient = databaseClient.Where(`"owner" = ?`, query.Staker.String())
+		databaseClient = databaseClient.Where(`"staker" = ?`, query.Staker.String())
 	}
 
 	if query.Node != nil {
 		databaseClient = databaseClient.Where(`"node" = ?`, query.Node.String())
 	}
 
-	type StakeStaking struct {
-		Owner string          `gorm:"column:owner"`
-		Node  string          `gorm:"column:node"`
-		Value decimal.Decimal `gorm:"column:value"`
-		Count uint64          `gorm:"column:count"`
-	}
-
-	var stakeStakings []*StakeStaking
+	var stakeStakings []*table.StakeStaking
 	if err := databaseClient.
-		Select(`"owner", "node", count(*) AS "count", sum("value") AS "value"`).
-		Group(`"owner", "node"`).
-		Order(`"owner", "node"`).
 		Limit(query.Limit).
+		Order(`"value" DESC, "staker", "node"`).
 		Find(&stakeStakings).Error; err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return nil, err
 	}
 
-	results := make([]*schema.StakeStaking, 0, len(stakeStakings))
+	resultsPool := pool.NewWithResults[*schema.StakeStaking]().WithContext(ctx).WithFirstError().WithCancelOnError()
 
 	for _, stakeStaking := range stakeStakings {
-		databaseClient := c.database.WithContext(ctx)
+		stakeStaking := stakeStaking
 
-		var stakeChips []*table.StakeChip
-		if err := databaseClient.
-			Where(
-				`"owner" = ? AND "node" = ? AND "owner" != ?`, stakeStaking.Owner, stakeStaking.Node, ethereum.AddressGenesis.String(),
-			).
-			Order(`"id"`).
-			Limit(5).
-			Find(&stakeChips).Error; err != nil {
-			return nil, err
-		}
+		resultsPool.Go(func(ctx context.Context) (*schema.StakeStaking, error) {
+			databaseClient := c.database.WithContext(ctx)
 
-		results = append(results, &schema.StakeStaking{
-			Staker: common.HexToAddress(stakeStaking.Owner),
-			Node:   common.HexToAddress(stakeStaking.Node),
-			Value:  stakeStaking.Value,
-			Chips: schema.StakeStakingChips{
-				Total: stakeStaking.Count,
-				Showcase: lo.Map(stakeChips, func(stakeChip *table.StakeChip, _ int) *schema.StakeChip {
-					result, _ := stakeChip.Export()
+			var stakeChips []*table.StakeChip
+			if err := databaseClient.
+				Where(`"owner" = ? AND "node" = ?`, stakeStaking.Staker, stakeStaking.Node).
+				Order(`"id" DESC`).
+				Limit(5).
+				Find(&stakeChips).Error; err != nil {
+				return nil, err
+			}
 
-					return result
-				}),
-			},
+			stakeStaking, err := stakeStaking.Export()
+			if err != nil {
+				return nil, fmt.Errorf("export stake staking: %w", err)
+			}
+
+			stakeStaking.Chips.Showcase = lo.Map(stakeChips, func(stakeChip *table.StakeChip, _ int) *schema.StakeChip {
+				return lo.Must(stakeChip.Export())
+			})
+
+			return stakeStaking, nil
 		})
 	}
+
+	results, err := resultsPool.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	slices.SortStableFunc(results, func(left, right *schema.StakeStaking) int {
+		if n := right.Value.Cmp(left.Value); n != 0 { // DESC
+			return n
+		}
+
+		if n := strings.Compare(left.Staker.String(), right.Staker.String()); n != 0 { // ASC
+			return n
+		}
+
+		return strings.Compare(left.Node.String(), right.Node.String()) // ASC
+	})
 
 	return results, nil
 }

--- a/internal/database/dialer/cockroachdb/migration/20240719073352_create_owner_and_node_and_value_and_finalized_index_for_chips.sql
+++ b/internal/database/dialer/cockroachdb/migration/20240719073352_create_owner_and_node_and_value_and_finalized_index_for_chips.sql
@@ -1,0 +1,17 @@
+-- +goose Up
+-- +goose StatementBegin
+CREATE INDEX "idx_owner_node_value_finalized" ON "stake"."chips" ("owner", "node") STORING ("value", "finalized");
+
+CREATE VIEW "stake"."stakings" AS
+SELECT "owner" AS "staker", "node", count(*) AS "count", sum("value") AS "value"
+FROM "stake"."chips"
+WHERE "finalized" IS TRUE
+GROUP BY "owner", "node";
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+DROP INDEX "stake"."idx_owner_node_value_finalized";
+
+DROP VIEW "stake"."stakings";
+-- +goose StatementEnd

--- a/internal/database/dialer/cockroachdb/table/stake_stacking.go
+++ b/internal/database/dialer/cockroachdb/table/stake_stacking.go
@@ -1,0 +1,45 @@
+package table
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/rss3-network/global-indexer/schema"
+	"github.com/shopspring/decimal"
+	gorm "gorm.io/gorm/schema"
+)
+
+var (
+	_ gorm.Tabler                    = (*StakeStaking)(nil)
+	_ schema.StakeStakingTransformer = (*StakeStaking)(nil)
+)
+
+type StakeStaking struct {
+	Staker string          `gorm:"column:staker"`
+	Node   string          `gorm:"column:node"`
+	Count  uint32          `gorm:"column:count"`
+	Value  decimal.Decimal `gorm:"column:value"`
+}
+
+func (s *StakeStaking) TableName() string {
+	return "stake.stakings"
+}
+
+func (s *StakeStaking) Import(stakeStaking schema.StakeStaking) error {
+	s.Staker = stakeStaking.Staker.String()
+	s.Node = stakeStaking.Node.String()
+	s.Value = stakeStaking.Value
+
+	return nil
+}
+
+func (s *StakeStaking) Export() (*schema.StakeStaking, error) {
+	stakeStaker := schema.StakeStaking{
+		Staker: common.HexToAddress(s.Staker),
+		Node:   common.HexToAddress(s.Node),
+		Value:  s.Value,
+		Chips: schema.StakeStakingChips{
+			Total: uint64(s.Count),
+		},
+	}
+
+	return &stakeStaker, nil
+}

--- a/internal/service/hub/handler/nta/stake_staking.go
+++ b/internal/service/hub/handler/nta/stake_staking.go
@@ -52,7 +52,9 @@ func (n *NTA) GetStakeStakings(c echo.Context) error {
 	}
 
 	if length := len(stakeStakings); length > 0 && length == request.Limit {
-		response.Cursor = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s-%s", stakeStakings[length-1].Staker.String(), stakeStakings[length-1].Node.String())))
+		latestStakeStaking := stakeStakings[length-1]
+
+		response.Cursor = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s-%s-%s", latestStakeStaking.Value, latestStakeStaking.Staker, latestStakeStaking.Node)))
 	}
 
 	return c.JSON(http.StatusOK, response)

--- a/schema/stake_staking.go
+++ b/schema/stake_staking.go
@@ -5,9 +5,17 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+type StakeStakingExporter interface {
+	Export() (*StakeStaking, error)
+}
+
+type StakeStakingTransformer interface {
+	StakeStakingExporter
+}
+
 type StakeStaking struct {
-	Staker common.Address    `json:"staker,omitempty"`
-	Node   common.Address    `json:"node,omitempty"`
+	Staker common.Address    `json:"staker"`
+	Node   common.Address    `json:"node"`
 	Value  decimal.Decimal   `json:"value"`
 	Chips  StakeStakingChips `json:"chips"`
 }


### PR DESCRIPTION
I used [STORING](https://www.cockroachlabs.com/docs/stable/indexes#storing-columns) to create a new index to solve a slow query problem specific to CockroachDB, and created a view to simplify gorm query statements.

```bash
$ curl -o /dev/null -s -w "%{time_total}s\n" "http://localhost/nta/stakings/stakings?cursor=MTk5OTMwNzE2ODYyODA4OTM0NDk1NDgyMC0weDZFMzZGYUQyNDdlRmZmMmJlNjQzMjcyM0RCMTk4MDQxZDI0YzJDRTktMHg2OTk4MkUwMTdBY2MwRkRFM2QxNTQyMjA1MDg5QThkM0VBZmNEMUI3"
0.095872s
```