### PR TITLE
feat: add tolerance_seconds config

### DIFF
--- a/deploy/config.example.yaml
+++ b/deploy/config.example.yaml
@@ -56,4 +56,5 @@ distributor:
   max_demotion_count: -1
   qualified_node_count: 3
   verification_count: 3
+  tolerance_seconds: 1200
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -68,6 +68,7 @@ type Distributor struct {
 	QualifiedNodeCount int `yaml:"qualified_node_count" default:"3"`
 	// The number of verification activities selected during the second verification.
 	VerificationCount int `yaml:"verification_count" default:"3"`
+	ToleranceSeconds  int `yaml:"tolerance_seconds" default:"1200"`
 }
 
 type SpecialRewards struct {
@@ -152,6 +153,7 @@ func initGlobalVars(file *File) {
 	model.DemotionCountBeforeSlashing = file.Distributor.MaxDemotionCount
 	model.RequiredVerificationCount = file.Distributor.VerificationCount
 	model.RequiredQualifiedNodeCount = file.Distributor.QualifiedNodeCount
+	model.ToleranceSeconds = file.Distributor.ToleranceSeconds
 
-	zap.L().Info("init constants", zap.Any("MaxDemotionCount", model.DemotionCountBeforeSlashing), zap.Any("VerificationCount", model.RequiredVerificationCount), zap.Any("QualifiedNodeCount", model.RequiredQualifiedNodeCount))
+	zap.L().Info("init constants", zap.Any("MaxDemotionCount", model.DemotionCountBeforeSlashing), zap.Any("VerificationCount", model.RequiredVerificationCount), zap.Any("QualifiedNodeCount", model.RequiredQualifiedNodeCount), zap.Any("ToleranceSeconds", model.ToleranceSeconds))
 }

--- a/internal/service/hub/handler/dsl/model/model.go
+++ b/internal/service/hub/handler/dsl/model/model.go
@@ -49,6 +49,8 @@ var (
 	RequiredVerificationCount = 3
 	// DemotionCountBeforeSlashing the number of demotions that trigger a slashing
 	DemotionCountBeforeSlashing = 4
+	// ToleranceSeconds is the tolerance seconds for the activity.
+	ToleranceSeconds = 20 * 60
 
 	// MutablePlatformMap is a map of mutable platforms which should be excluded from the data comparison.
 	MutablePlatformMap = map[string]struct{}{
@@ -122,16 +124,17 @@ type MetaCursor struct {
 
 // Activity represents an activity.
 type Activity struct {
-	ID       string    `json:"id"`
-	Owner    string    `json:"owner,omitempty"`
-	Network  string    `json:"network"`
-	Index    uint      `json:"index"`
-	From     string    `json:"from"`
-	To       string    `json:"to"`
-	Tag      string    `json:"tag"`
-	Type     string    `json:"type"`
-	Platform string    `json:"platform,omitempty"`
-	Actions  []*Action `json:"actions"`
+	ID        string    `json:"id"`
+	Owner     string    `json:"owner,omitempty"`
+	Network   string    `json:"network"`
+	Index     uint      `json:"index"`
+	From      string    `json:"from"`
+	To        string    `json:"to"`
+	Tag       string    `json:"tag"`
+	Type      string    `json:"type"`
+	Platform  string    `json:"platform,omitempty"`
+	Actions   []*Action `json:"actions"`
+	Timestamp uint64    `json:"timestamp"`
 }
 
 // Action represents an action within an Activity.


### PR DESCRIPTION
The `tolerance_seconds` parameter addresses data inconsistencies arising from varying indexing speeds across nodes. It's defaulted to the time span of a tolerable block count in the indexed network.