### PR TITLE
fix: validate no_scheme for /decentralized

### DIFF
--- a/internal/service/hub/hub.go
+++ b/internal/service/hub/hub.go
@@ -35,7 +35,11 @@ type Hub struct {
 var _ echo.Validator = (*Validator)(nil)
 
 var defaultValidator = &Validator{
-	validate: validator.New(),
+	validate: func() *validator.Validate {
+		v := validator.New()
+		v.RegisterValidation("no_scheme", validateNoScheme) //nolint:errcheck
+		return v
+	}(),
 }
 
 type Validator struct {

--- a/internal/service/hub/model/dsl/decentralized.go
+++ b/internal/service/hub/model/dsl/decentralized.go
@@ -9,7 +9,7 @@ type ActivityRequest struct {
 
 // ActivitiesRequest represents the request for activities by an account.
 type ActivitiesRequest struct {
-	Account        string   `param:"account" validate:"required"`
+	Account        string   `param:"account" validate:"required,no_scheme"`
 	Limit          *int     `query:"limit" validate:"min=1,max=100" default:"100"`
 	ActionLimit    *int     `query:"action_limit" validate:"min=1,max=20" default:"10"`
 	Cursor         *string  `query:"cursor"`
@@ -25,7 +25,7 @@ type ActivitiesRequest struct {
 
 // AccountsActivitiesRequest represents the request for activities by multiple accounts.
 type AccountsActivitiesRequest struct {
-	Accounts       []string `json:"accounts" validate:"required,max=20"`
+	Accounts       []string `json:"accounts" validate:"required,max=20,no_scheme"`
 	Limit          int      `json:"limit" validate:"min=1,max=100" default:"100"`
 	ActionLimit    int      `json:"action_limit" validate:"min=1,max=20" default:"10"`
 	Cursor         *string  `json:"cursor"`

--- a/internal/service/hub/validator.go
+++ b/internal/service/hub/validator.go
@@ -1,0 +1,13 @@
+package hub
+
+import (
+	"strings"
+
+	"github.com/go-playground/validator/v10"
+)
+
+// Custom validation for no "://"
+func validateNoScheme(fl validator.FieldLevel) bool {
+	account := fl.Field().String()
+	return !strings.Contains(account, "://")
+}


### PR DESCRIPTION
MVP to test the validation:

```golang
package main

import (
	"net/http"
	"strings"

	"github.com/go-playground/validator/v10"
	"github.com/labstack/echo/v4"
	"github.com/labstack/echo/v4/middleware"
)

// Validator struct with embedded validator.Validate
type Validator struct {
	validate *validator.Validate
}

// Validate method to validate a struct
func (v *Validator) Validate(i interface{}) error {
	return v.validate.Struct(i)
}

// Custom validation for no "://"
func validateNoScheme(fl validator.FieldLevel) bool {
	account := fl.Field().String()
	return !strings.Contains(account, "://")
}

// Define the default validator with custom validation rules
var defaultValidator = &Validator{
	validate: func() *validator.Validate {
		v := validator.New()
		// Register custom validations
		v.RegisterValidation("no_scheme", validateNoScheme) //nolint:errcheck
		return v
	}(),
}

// ActivitiesRequest struct to validate
type ActivitiesRequest struct {
	Account string `query:"account" validate:"required,no_scheme"`
}

func main() {
	// Create a new Echo instance
	e := echo.New()

	// Use the default validator with custom rules
	e.Validator = defaultValidator

	// Middleware
	e.Use(middleware.Logger())
	e.Use(middleware.Recover())

	// Test validation route
	e.GET("/validate", func(c echo.Context) error {
		req := new(ActivitiesRequest)
		if err := c.Bind(req); err != nil {
			return c.JSON(http.StatusBadRequest, map[string]string{"error": "Invalid input"})
		}

		// Validate the request
		if err := c.Validate(req); err != nil {
			return c.JSON(http.StatusBadRequest, map[string]string{"error": err.Error()})
		}

		return c.JSON(http.StatusOK, map[string]string{"message": "Validation passed!"})
	})

	// Start the server
	e.Logger.Fatal(e.Start(":8080"))
}

```